### PR TITLE
Fixed typo in a comment of commands.yml

### DIFF
--- a/src/main/resources/commands.yml
+++ b/src/main/resources/commands.yml
@@ -231,7 +231,7 @@ commands:
           - "warp"
     # The guild command.
     guild:
-      # Enables / disables the use of the "party" bungee command.
+      # Enables / disables the use of the "guild" bungee command.
       enabled: true
       # Main command that the aliases point to.
       base: "guild"

--- a/target/classes/commands.yml
+++ b/target/classes/commands.yml
@@ -231,7 +231,7 @@ commands:
           - "warp"
     # The guild command.
     guild:
-      # Enables / disables the use of the "party" bungee command.
+      # Enables / disables the use of the "guild" bungee command.
       enabled: true
       # Main command that the aliases point to.
       base: "guild"


### PR DESCRIPTION
I noticed this typo whilst editing commands.yml and wanted to fix it.